### PR TITLE
Added requirements.txt file to simplify installation, .gitignore file and small section to troubleshoot errors on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,111 @@
+# From: https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+#################################################################################
+# CUSTOM
+# output files
+out.csv

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ The script requires a couple of packages (e.g. Beautiful Soup 4), you can instal
 ![bitcoin chart](https://raw.githubusercontent.com/Pold87/academic-keyword-occurrence/master/bitcoin_chart.png "bitcoin chart")
  
 
+## Troubleshooting
+_OSX only_: Python 3.6 does not include any SSL certificates, therefore any `https`
+request will fail due to the impossibility to verify the URL.
+
+This will lead to the following error:
+
+```
+urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed
+```
+
+_Fix_: Execute `/Applications/Python\ 3.6/Install\ Certificates.command` to
+install the `certifi` package. (More details: https://stackoverflow.com/a/42334357)
+
+
 ## Credits
 Created by Volker Strobel - volker.strobel87@gmail.com
   		  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4==4.6.0


### PR DESCRIPTION
- added the `requirements.txt` file to simplify installation, just run `pip install -r requirements.txt` (tested in a virtual environment running Python3.6).
- added `.gitignore` file (to ignore python non-source files and output.csv).
- added a small section to troubleshoot errors on OSX in the README (how to fix the SSL error on Python3.6).